### PR TITLE
Feature/save a users playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # jammming
-Spotify Playlist App for CodeAcademy
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) for CodeAcademy's [Create a Playlist App with the Spotify API](https://www.codecademy.com/projects/portfolio/jammming-react18) portfolio project.
+
+For an additional challenge, I chose to write it in TypeScript.
 
 ## Available Scripts
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,17 +1,11 @@
 # Next Step
 
-Implement Spotify Search Request
+Save a User's Playlist
 
-Connect the search bar to Spotify so that it can query data from the Spotify API. Your implementation should enable users to enter a search parameter and receive a response from the Spotify API. You should display the results from the request to the user.
+Create a method that writes the user’s custom playlist in Jammming to their Spotify account. The user should be able to save their custom playlist from Jammming into their account when they click the “Save To Spotify” button.
 
-To make your request to the API, use the `/v1/search?type=TRACK` endpoint. You can refer to the [Spotify Web API Endpoint Reference](https://developer.spotify.com/documentation/web-api/reference/#/) for guidance on formatting your request.
+To implement this feature, you will need to make requests to create new playlists on the user’s Spotify account with the playlist’s custom name and add the tracks from the user’s custom playlist to the new playlist.
 
-You can use `fetch()` to make your `GET` requests and you should be expecting the response back as a list of tracks in JSON format.
-
-It is best to convert the JSON to an array of tracks, the array should be a list of track objects with the following properties: `id`, `name`, `artist`, `album`, and `uri`.
-
-Common errors to avoid:
-
-- Invalid access tokens: Make sure that you use valid access tokens before making your requests.
-- Incorrect API endpoint: Make sure you use `/v1/search?type=TRACK` as outlined in the documentation.
-- Incorrectly formatted requests: Refer to the Endpoint Reference documentation for guidance on how to format your requests.
+- To hit the necessary endpoints, you’ll need the user’s ID, you can make a request that returns the user’s Spotify username by making a request to `https://api.spotify.com/v1/me`.
+- To create a new playlist, you will need to make a POST request to the `/v1/users/{user_id}/playlists` endpoint. You can set the name and description of the new playlist in the request body.
+- To add tracks to the new playlist, you will need to make a POST request to the `//v1/users/{user_id}/playlists/{playlist_id}/tracks` endpoint. You can provide a list of track IDs in the request body to add them to the playlist.

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -17,7 +17,7 @@ describe('SearchBar', () => {
 
   const userInit = {
     isLoggedIn: false,
-    displayName: null,
+    user: null,
     accessToken: null,
     expiresAt: null,
   };

--- a/src/components/Track/Track.module.css
+++ b/src/components/Track/Track.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  color:aliceblue;
+  color: aliceblue;
   border: 2px solid;
   border-color: black;
   margin: 5px;
@@ -32,6 +32,7 @@
     background-color: transparent;
     font-size: 1.5em;
     font-weight: bold;
+    padding: 10px;
   }
 
   button:hover {
@@ -42,5 +43,4 @@
   button:active {
     font-size: 1em;
   }
-
 }

--- a/src/containers/App/App.test.tsx
+++ b/src/containers/App/App.test.tsx
@@ -100,7 +100,7 @@ describe('App', () => {
       '#access_token=efgh5678&token_type=Bearer&expires_in=3600&state=1234';
 
     const mockGetUser: Awaited<ReturnType<typeof spotifyAPI.getUser>> = {
-      display_name: 'Test User',
+      displayName: 'Test User',
       id: 'testuser',
     };
 

--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -22,7 +22,7 @@ function App() {
 
   const userInitialValues = {
     isLoggedIn: false,
-    displayName: null,
+    user: null,
     accessToken: null,
     expiresAt: null,
   };

--- a/src/containers/LoginContainer/LoginConatiner.test.tsx
+++ b/src/containers/LoginContainer/LoginConatiner.test.tsx
@@ -26,7 +26,7 @@ describe('LoginContainer', () => {
 
   const userInit = {
     isLoggedIn: false,
-    displayName: null,
+    user: null,
     accessToken: null,
     expiresAt: null,
   };
@@ -91,7 +91,7 @@ describe('LoginContainer', () => {
       '#access_token=efgh5678&token_type=Bearer&expires_in=3600&state=1234';
 
     const mockGetUser: Awaited<ReturnType<typeof spotifyAPI.getUser>> = {
-      display_name: 'Test User',
+      displayName: 'Test User',
       id: 'testuser',
     };
 
@@ -123,7 +123,7 @@ describe('LoginContainer', () => {
       '#access_token=efgh5678&token_type=Bearer&expires_in=3600&state=1234';
 
     const mockGetUser: Awaited<ReturnType<typeof spotifyAPI.getUser>> = {
-      display_name: 'Test User',
+      displayName: 'Test User',
       id: 'testuser',
     };
 

--- a/src/containers/LoginContainer/LoginContainer.tsx
+++ b/src/containers/LoginContainer/LoginContainer.tsx
@@ -9,8 +9,8 @@ function LoginContainer() {
   const {
     isLoggedIn,
     setIsLoggedIn,
-    displayName,
-    setDisplayName,
+    user,
+    setUser,
     accessToken,
     setAccessToken,
     expiresAt,
@@ -49,15 +49,11 @@ function LoginContainer() {
     window.history.pushState({}, document.title, '/');
   }, []);
 
-  async function getDisplayName() {
-    const displayName = await spotifyAPI
-      .getUser(stateKey, accessToken)
-      .then((jsonResponse) => {
-        return jsonResponse.display_name;
-      });
+  async function getUserData() {
+    const userResponse = await spotifyAPI.getUser(stateKey, accessToken);
 
-    if (displayName) {
-      setDisplayName(displayName);
+    if (userResponse) {
+      setUser(userResponse);
       setIsLoggedIn(true);
     }
   }
@@ -68,7 +64,7 @@ function LoginContainer() {
 
   useEffect(() => {
     if (accessToken && expiresAt) {
-      getDisplayName();
+      getUserData();
       const timeRemaining = expiresAt - Date.now();
       const timeout = setTimeout(() => {
         alert('Authentication timeout, please log in again');
@@ -85,7 +81,7 @@ function LoginContainer() {
   return (
     <div id="login" className={styles.login}>
       {isLoggedIn ? (
-        <p>Logged in as {displayName}</p>
+        <p>Logged in as {user?.displayName}</p>
       ) : (
         <button
           id="login-button"

--- a/src/containers/LoginContainer/LoginContainer.tsx
+++ b/src/containers/LoginContainer/LoginContainer.tsx
@@ -69,6 +69,7 @@ function LoginContainer() {
       const timeout = setTimeout(() => {
         alert('Authentication timeout, please log in again');
         setAccessToken(null);
+        setUser(null);
         setIsLoggedIn(false);
         setExpiresAt(null);
       }, timeRemaining);

--- a/src/containers/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/containers/PlaylistContainer/PlaylistContainer.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
-import { TrackButton, PlaylistContextType } from '../../utils/types';
+import {
+  TrackButton,
+  PlaylistContextType,
+  UserContextType,
+} from '../../utils/types';
 import Playlist from '../../components/Playlist/Playlist';
-import styles from './PlaylistContainer.module.css';
 import { PlaylistContext } from '../../context/PlaylistContext';
+import { UserContext } from '../../context/UserContext';
+import styles from './PlaylistContainer.module.css';
+import spotifyAPI from '../../utils/spotifyAPI';
 
 function PlaylistContainer() {
   const {
     playlistTracks,
+    setPlaylistTracks,
     playlistName,
     setPlaylistName,
     hasTracklist,
     removeTrack,
-    setPlaylistURIs,
   } = React.useContext(PlaylistContext) as PlaylistContextType;
+
+  const { user, accessToken } = React.useContext(
+    UserContext
+  ) as UserContextType;
 
   const handlePlaylistNameChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setPlaylistName(e.currentTarget.value);
@@ -22,11 +32,38 @@ function PlaylistContainer() {
     callback: removeTrack,
   };
 
+  const submitPlaylist = async (userId: string, trackURIs: string[]) => {
+    try {
+      const playlistId = await spotifyAPI.createPlaylist(
+        userId,
+        accessToken,
+        playlistName
+      );
+      const result = await spotifyAPI.addTracks(
+        accessToken,
+        playlistId,
+        trackURIs
+      );
+
+      if (result === 'success') {
+        alert(
+          `Your play list "${playlistName}" has been successfully saved to your Spotify account ${user?.displayName}`
+        );
+        setPlaylistTracks([]);
+        setPlaylistName('');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+    return;
+  };
+
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     const uris = playlistTracks.map((e) => e.uri);
-    setPlaylistURIs(uris);
-
+    if (user) {
+      submitPlaylist(user.id, uris);
+    }
     return;
   };
 

--- a/src/context/PlaylistContext.tsx
+++ b/src/context/PlaylistContext.tsx
@@ -15,7 +15,6 @@ const PlaylistProvider: React.FC<{
     initialValues.tracks
   );
   const [playlistName, setPlaylistName] = useState(initialValues.name);
-  const [playlistURIs, setPlaylistURIs] = useState<string[]>([]);
   const [hasTracklist, setHasTracklist] = useState(false);
 
   const addTrack = (track: TrackData) => {
@@ -45,28 +44,16 @@ const PlaylistProvider: React.FC<{
     }
   }, [playlistTracks]);
 
-  useEffect(() => {
-    if (playlistURIs.length > 0) {
-      console.log(playlistName);
-      console.log(playlistURIs);
-      console.log('before setPlaylistTracks');
-      setPlaylistTracks([]);
-      setPlaylistName('');
-      console.log('after setPlaylistTracks');
-    }
-  }, [playlistURIs]);
-
   return (
     <PlaylistContext.Provider
       value={{
         playlistTracks,
         playlistName,
-        playlistURIs,
         hasTracklist,
         addTrack,
         removeTrack,
         setPlaylistName,
-        setPlaylistURIs,
+        setPlaylistTracks,
       }}
     >
       {children}

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -8,17 +8,17 @@ const UserProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ initialValues, children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(initialValues.isLoggedIn);
-  const [displayName, setDisplayName] = useState(initialValues.displayName);
   const [accessToken, setAccessToken] = useState(initialValues.accessToken);
   const [expiresAt, setExpiresAt] = useState(initialValues.expiresAt);
+  const [user, setUser] = useState(initialValues.user);
 
   return (
     <UserContext.Provider
       value={{
         isLoggedIn,
         setIsLoggedIn,
-        displayName,
-        setDisplayName,
+        user,
+        setUser,
         accessToken,
         setAccessToken,
         expiresAt,

--- a/src/utils/__mocks__/spotifyAPI.tsx
+++ b/src/utils/__mocks__/spotifyAPI.tsx
@@ -2,7 +2,7 @@ const spotifyAPI = {
   logIn: jest.fn(),
   getUser: jest.fn(() => {
     Promise.resolve({
-      display_name: '',
+      displayName: '',
       id: '',
     });
   }),

--- a/src/utils/__mocks__/spotifyAPI.tsx
+++ b/src/utils/__mocks__/spotifyAPI.tsx
@@ -15,6 +15,12 @@ const spotifyAPI = {
       previous: null,
     });
   }),
+  createPlaylist: jest.fn(() => {
+    Promise.resolve('');
+  }),
+  addTracks: jest.fn(() => {
+    Promise.resolve('');
+  }),
 };
 
 export default spotifyAPI;

--- a/src/utils/spotifyAPI.tsx
+++ b/src/utils/spotifyAPI.tsx
@@ -21,7 +21,8 @@ const spotifyAPI = {
 
     localStorage.setItem(stateKey, state);
 
-    const scope = 'user-read-private user-read-email';
+    const scope =
+      'user-read-email playlist-modify-public playlist-modify-private';
 
     let url = 'https://accounts.spotify.com/authorize';
     url += '?response_type=token';
@@ -61,8 +62,6 @@ const spotifyAPI = {
     return `https://api.spotify.com/v1/search?${query}`;
   },
   getTracks(endpoint: string, accessToken: string | null) {
-    console.log(`Client: ${CLIENT_ID}`);
-
     return fetch(endpoint, {
       headers: {
         Authorization: 'Bearer ' + accessToken,
@@ -129,6 +128,77 @@ const spotifyAPI = {
       })
       .catch((error) => {
         console.error('Error fetching and parsing data', error);
+      });
+  },
+  createPlaylist(userId: string, accessToken: string | null, name: string) {
+    console.log(`Client: ${CLIENT_ID}`);
+
+    const endpoint = `https://api.spotify.com/v1/users/${userId}/playlists`;
+
+    return fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + accessToken,
+      },
+      body: JSON.stringify({
+        name: name,
+        description: 'Playlist made with Jammming',
+        public: false,
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((errorResponse) => {
+            console.error('API error: ', errorResponse);
+            throw new Error('API error');
+          });
+        }
+        return response.json();
+      })
+      .then((jsonResponse) => {
+        return jsonResponse.id;
+      })
+      .catch((error) => {
+        console.error('Error posting data', error);
+      });
+  },
+  addTracks(
+    accessToken: string | null,
+    playlistId: string,
+    trackUris: string[]
+  ) {
+    const endpoint = `https://api.spotify.com/v1/playlists/${playlistId}/tracks`;
+
+    return fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + accessToken,
+      },
+      body: JSON.stringify({
+        uris: trackUris,
+        position: 0,
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((errorResponse) => {
+            console.error('API error: ', errorResponse);
+            throw new Error('API error');
+          });
+        }
+        return response.json();
+      })
+      .then((jsonResponse) => {
+        if (jsonResponse.snapshot_id) {
+          console.log('success');
+          return 'success';
+        } else {
+          console.log('failure');
+          return 'failure';
+        }
+      })
+      .catch((error) => {
+        console.error('Error posting data', error);
       });
   },
 };

--- a/src/utils/spotifyAPI.tsx
+++ b/src/utils/spotifyAPI.tsx
@@ -40,15 +40,22 @@ const spotifyAPI = {
       headers: {
         Authorization: 'Bearer ' + accessToken,
       },
-    }).then((response) => {
-      if (!response.ok) {
-        return response.json().then((errorResponse) => {
-          console.error('API error: ', errorResponse);
-          throw new Error('API error');
-        });
-      }
-      return response.json();
-    });
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((errorResponse) => {
+            console.error('API error: ', errorResponse);
+            throw new Error('API error');
+          });
+        }
+        return response.json();
+      })
+      .then((jsonResponse) => {
+        return {
+          displayName: jsonResponse.display_name,
+          id: jsonResponse.id,
+        };
+      });
   },
   getSearchEndpoint(query: string) {
     return `https://api.spotify.com/v1/search?${query}`;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -51,8 +51,8 @@ export interface PlaylistContextType {
 export interface UserContextType {
   isLoggedIn: boolean;
   setIsLoggedIn: (value: React.SetStateAction<boolean>) => void;
-  displayName: string | null;
-  setDisplayName: (value: React.SetStateAction<string | null>) => void;
+  user: User | null;
+  setUser: (value: React.SetStateAction<User | null>) => void;
   accessToken: string | null;
   setAccessToken: (value: React.SetStateAction<string | null>) => void;
   expiresAt: number | null;
@@ -72,7 +72,12 @@ export interface PlaylistInitialValues {
 
 export interface UserInitialValues {
   isLoggedIn: boolean;
-  displayName: string | null;
   accessToken: string | null;
   expiresAt: number | null;
+  user: User | null;
+}
+
+export interface User {
+  displayName: string;
+  id: string;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -39,13 +39,12 @@ export interface SearchContextType {
 
 export interface PlaylistContextType {
   playlistTracks: TrackData[];
+  setPlaylistTracks: (value: React.SetStateAction<TrackData[]>) => void;
   playlistName: string;
-  playlistURIs: string[] | null;
   hasTracklist: boolean;
   addTrack: (track: TrackData) => void;
   removeTrack: (track: TrackData) => void;
   setPlaylistName: (value: React.SetStateAction<string>) => void;
-  setPlaylistURIs: (value: React.SetStateAction<string[]>) => void;
 }
 
 export interface UserContextType {


### PR DESCRIPTION
### Acceptance Criteria

- Create a method that writes the user’s custom playlist in Jammming to their Spotify account when the user clicks the “Save To Spotify” button.

### Change Log

- Stores user data as single state object rather than discrete data points
- Cleaned up state that was unecessary
- Adds new methods to POST to Spotify's `/v1/users/{user_id}/playlists` and `/v1/playlists/{playlist_id}/tracks` endpoints.
- Alerts the user when the playlist has been successfully posted
- Re-setting the playlist now happens only after the user clicks the "ok" on the alert