### PR TITLE
Fix lint error causing pipeline fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Unit Tests
+name: Run Unit Tests and Build App
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -41,3 +41,25 @@ jobs:
         run: npm ci
       - name: Run linter
         run: npm run lint
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        env:
+          CI: true
+          REACT_APP_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
+        run: npx --no-install npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./build

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,17 @@ import './index.css';
 import App from './containers/App/App';
 import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+} else {
+  console.error('Root element not found');
+}
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
MAYBE THIS TIME the stupid build & deploy pipeline will work...

Adds the 'build' step into the PR test actions to catch linting errors that for some reason the regular linter won't